### PR TITLE
[PR] Add support for past events to content syndication

### DIFF
--- a/includes/class-wsu-syndicate-shortcode-events.php
+++ b/includes/class-wsu-syndicate-shortcode-events.php
@@ -16,6 +16,7 @@ class WSU_Syndicate_Shortcode_Events extends WSU_Syndicate_Shortcode_Base {
 	 */
 	public $local_extended_atts = array(
 		'category' => '',
+		'period' => '',
 	);
 
 	/**
@@ -53,6 +54,12 @@ class WSU_Syndicate_Shortcode_Events extends WSU_Syndicate_Shortcode_Base {
 		}
 
 		$request_url = esc_url( $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
+
+		if ( 'past' === $atts['period'] ) {
+			$request_url = add_query_arg( array(
+				'tribe_event_display' => 'past',
+			), $request_url );
+		}
 
 		if ( '' !== $atts['category'] ) {
 			$request_url = add_query_arg( array(


### PR DESCRIPTION
This adds support for a shortcode attribute `period="past"` to display only past events using the `wsuwp_events` shortcode.